### PR TITLE
Announce support for Galene protocol 2.

### DIFF
--- a/galene_stream/galene.py
+++ b/galene_stream/galene.py
@@ -122,7 +122,7 @@ class GaleneClient:
         log.info("Handshaking")
         msg = {
             "type": "handshake",
-            "version": ["1"],  # since Galene 0.6.0
+            "version": ["2", "1"],
             "id": self.client_id,
         }
         await self.send(msg)


### PR DESCRIPTION
Galene 0.7 will switch to a new protocol version.  Announce support for
protocol version 2.

Since we don't currently parse dates, no further changes are required.

https://lists.galene.org/galene/87sfhch6li.wl-jch@irif.fr/
